### PR TITLE
Fixed deprecated warnings.

### DIFF
--- a/lib/src/widgets/passthrough_overlay.dart
+++ b/lib/src/widgets/passthrough_overlay.dart
@@ -237,7 +237,8 @@ class PassthroughOverlay extends StatefulWidget {
   /// OverlayState overlay = Overlay.of(context);
   /// ```
   static PassthroughOverlayState of(BuildContext context, { Widget debugRequiredFor }) {
-    final PassthroughOverlayState result = context.ancestorStateOfType(const TypeMatcher<PassthroughOverlayState>());
+    final PassthroughOverlayState result =
+        context.findAncestorStateOfType<PassthroughOverlayState>();
     assert(() {
       if (debugRequiredFor != null && result == null) {
         final String additional = context.widget != debugRequiredFor

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -15,7 +15,6 @@ import 'package:flutter/rendering.dart';
 import './passthrough_overlay.dart';
 import './typedefs.dart';
 import './wrap.dart';
-import './transitions.dart';
 import '../rendering/wrap.dart';
 import 'reorderable_mixin.dart';
 


### PR DESCRIPTION
Replaced deprecated method ancestorStateOfType and TypeMatcher with their replacements
Removed unused dependency.