### PR TITLE
fixed assertion error

### DIFF
--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -9,11 +9,9 @@ import 'package:flutter/rendering.dart';
 import 'package:reorderables/reorderables.dart';
 
 import './passthrough_overlay.dart';
-
 //import './transitions.dart';
 import './typedefs.dart';
 import './wrap.dart';
-
 //import './transitions.dart';
 import '../rendering/wrap.dart';
 import 'reorderable_mixin.dart';
@@ -963,8 +961,10 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
         if (!willAccept) {
           return false;
         }
-        assert(_childDisplayIndexToIndex[_currentDisplayIndex] != index &&
-            _currentDisplayIndex != displayIndex);
+        if(!(_childDisplayIndexToIndex[_currentDisplayIndex] != index &&
+            _currentDisplayIndex != displayIndex)){
+          return false;
+        }
 
         if (_wrapKey.currentContext != null) {
           RenderWrapWithMainAxisCount wrapRenderObject =


### PR DESCRIPTION
When playing around with WrapExample, often an assertion was thrown when dragging around an item of the ReorderableWrap too quickly. The assertion error was thrown during instantiation of `nextDragTarget` (line 1006) by the assert statement in the function `onWillAccept` in line 966. 
I simply replaced the failing assertion by returning `false` instead. 