### PR TITLE
Flutter 2.5 deprecation fixes

### DIFF
--- a/lib/src/widgets/reorderable_flex.dart
+++ b/lib/src/widgets/reorderable_flex.dart
@@ -7,9 +7,9 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-import './reorderable_widget.dart';
 import './passthrough_overlay.dart';
 import './reorderable_mixin.dart';
+import './reorderable_widget.dart';
 import './typedefs.dart';
 
 /// Reorderable (drag and drop) version of [Flex], a widget that displays its
@@ -250,7 +250,6 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
   // The member of widget.children currently being dragged.
   //
   // Null if no drag is underway.
-  Key? _dragging;
   Widget? _draggingWidget;
 
   // The last computed size of the feedback widget being dragged.
@@ -440,7 +439,6 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
     void onDragStarted() {
       setState(() {
         _draggingWidget = toWrap;
-        _dragging = toWrap.key;
         _dragStartIndex = index;
         _ghostIndex = index;
         _currentIndex = index;
@@ -462,8 +460,6 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
       // specifications.
       _ghostController.reverse(from: 0.1);
       _entranceController.reverse(from: 0);
-
-      _dragging = null;
     }
 
     void reorder(int startIndex, int endIndex) {
@@ -524,8 +520,9 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
         }
         semanticsActions[CustomSemanticsAction(label: reorderItemAfter)] =
             moveAfter;
-        semanticsActions[CustomSemanticsAction(
-            label: localizations.reorderItemToEnd)] = moveToEnd;
+        semanticsActions[
+                CustomSemanticsAction(label: localizations.reorderItemToEnd)] =
+            moveToEnd;
       }
 
       // We pass toWrap with a GlobalKey into the Draggable so that when a list
@@ -632,9 +629,8 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
                     child: Opacity(
                         opacity: 0,
                         child: Container(width: 0, height: 0, child: toWrap))),
-                //ConstrainedBox(constraints: contentConstraints),//SizedBox(),
-                dragAnchor: DragAnchor.child,
                 onDragStarted: onDragStarted,
+                dragAnchorStrategy: childDragAnchorStrategy,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,
@@ -660,8 +656,8 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
                     child: Opacity(
                         opacity: 0,
                         child: Container(width: 0, height: 0, child: toWrap))),
-                dragAnchor: DragAnchor.child,
                 onDragStarted: onDragStarted,
+                dragAnchorStrategy: childDragAnchorStrategy,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,

--- a/lib/src/widgets/reorderable_sliver.dart
+++ b/lib/src/widgets/reorderable_sliver.dart
@@ -13,8 +13,8 @@ import 'package:flutter/rendering.dart';
 import 'package:reorderables/reorderables.dart';
 
 import './basic.dart';
-import './typedefs.dart';
 import './reorderable_mixin.dart';
+import './typedefs.dart';
 
 int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 
@@ -249,7 +249,7 @@ class ReorderableSliverList extends StatefulWidget {
     this.enabled = true,
     this.controller,
     Key? key,
-  })  : super(key: key);
+  }) : super(key: key);
 
   /// The delegate that provides the children for this widget.
   ///
@@ -383,8 +383,9 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
       _attachedScrollPosition = null;
     }
 
-    _scrollController =
-        widget.controller ?? PrimaryScrollController.of(context) ?? ScrollController();
+    _scrollController = widget.controller ??
+        PrimaryScrollController.of(context) ??
+        ScrollController();
 
     _attachedScrollPosition =
         _scrollController.hasClients ? null : Scrollable.of(context)?.position;
@@ -696,8 +697,9 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
 //        }
         semanticsActions[CustomSemanticsAction(label: reorderItemAfter)] =
             moveAfter;
-        semanticsActions[CustomSemanticsAction(
-            label: localizations.reorderItemToEnd)] = moveToEnd;
+        semanticsActions[
+                CustomSemanticsAction(label: localizations.reorderItemToEnd)] =
+            moveToEnd;
       }
 
       // We pass toWrap with a GlobalKey into the Draggable so that when a list
@@ -808,9 +810,8 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
                       opacity: 0,
 //              child: _makeAppearingWidget(toWrap)
                       child: Container(width: 0, height: 0, child: toWrap)))),
-          //ConstrainedBox(constraints: contentConstraints),//SizedBox(),
-          dragAnchor: DragAnchor.child,
           onDragStarted: onDragStarted,
+          dragAnchorStrategy: childDragAnchorStrategy,
           // When the drag ends inside a DragTarget widget, the drag
           // succeeds, and we reorder the widget into position appropriately.
           onDragCompleted: onDragEnded,

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -9,11 +9,9 @@ import 'package:flutter/rendering.dart';
 import 'package:reorderables/reorderables.dart';
 
 import './passthrough_overlay.dart';
-
 //import './transitions.dart';
 import './typedefs.dart';
 import './wrap.dart';
-
 //import './transitions.dart';
 import '../rendering/wrap.dart';
 import 'reorderable_mixin.dart';
@@ -840,12 +838,11 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
                         opacity: 0.2,
                         //child: toWrap,//Container(width: 0, height: 0, child: toWrap)
                         child: _makeAppearingWidget(toWrap))),
-                //ConstrainedBox(constraints: contentConstraints),//SizedBox(),
-                dragAnchor: DragAnchor.child,
                 onDragStarted: onDragStarted,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,
+                dragAnchorStrategy: childDragAnchorStrategy,
                 // When the drag does not end inside a DragTarget widget, the
                 // drag fails, but we still reorder the widget to the last position it
                 // had been dragged to.
@@ -868,9 +865,9 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
                     child: _makeAppearingWidget(toWrap),
                   ),
                 ),
-                dragAnchor: DragAnchor.child,
                 onDragStarted: onDragStarted,
                 onDragCompleted: onDragEnded,
+                dragAnchorStrategy: childDragAnchorStrategy,
                 onDraggableCanceled: (Velocity velocity, Offset offset) =>
                     onDragEnded(),
               );


### PR DESCRIPTION
Looks like `Draggable.dragAnchor` is now deprecated, and they want us to use `dragAnchorStrategy` instead.

@hanshengchiu please review at your earliest convenience, so that I can attempt to deploy a release to pub.dev tomorrow night. Thanks in advance.