### PR TITLE
fix: missing dragAnchorStrategy,revert to dragAnchor.

### DIFF
--- a/lib/src/widgets/reorderable_flex.dart
+++ b/lib/src/widgets/reorderable_flex.dart
@@ -630,7 +630,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
                         opacity: 0,
                         child: Container(width: 0, height: 0, child: toWrap))),
                 onDragStarted: onDragStarted,
-                dragAnchorStrategy: childDragAnchorStrategy,
+                dragAnchor: DragAnchor.child,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,
@@ -657,7 +657,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
                         opacity: 0,
                         child: Container(width: 0, height: 0, child: toWrap))),
                 onDragStarted: onDragStarted,
-                dragAnchorStrategy: childDragAnchorStrategy,
+                dragAnchor: DragAnchor.child,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,

--- a/lib/src/widgets/reorderable_sliver.dart
+++ b/lib/src/widgets/reorderable_sliver.dart
@@ -811,7 +811,7 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
 //              child: _makeAppearingWidget(toWrap)
                       child: Container(width: 0, height: 0, child: toWrap)))),
           onDragStarted: onDragStarted,
-          dragAnchorStrategy: childDragAnchorStrategy,
+          dragAnchor: DragAnchor.child,
           // When the drag ends inside a DragTarget widget, the drag
           // succeeds, and we reorder the widget into position appropriately.
           onDragCompleted: onDragEnded,

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -842,7 +842,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,
-                dragAnchorStrategy: childDragAnchorStrategy,
+                dragAnchor: DragAnchor.child,
                 // When the drag does not end inside a DragTarget widget, the
                 // drag fails, but we still reorder the widget to the last position it
                 // had been dragged to.
@@ -867,7 +867,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
                 ),
                 onDragStarted: onDragStarted,
                 onDragCompleted: onDragEnded,
-                dragAnchorStrategy: childDragAnchorStrategy,
+                dragAnchor: DragAnchor.child,
                 onDraggableCanceled: (Velocity velocity, Offset offset) =>
                     onDragEnded(),
               );


### PR DESCRIPTION
Hello, I noticed that LongPressDraggable has no dragAnchorStrategy, and I reverted it to dragAnchor. This bug made version 0.4.2 can not work normally..