### PR TITLE
Add ReorderingCallback with DragUpdateDetails

### DIFF
--- a/lib/src/widgets/reorderable_flex.dart
+++ b/lib/src/widgets/reorderable_flex.dart
@@ -51,6 +51,7 @@ class ReorderableFlex extends StatefulWidget {
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.onNoReorder,
     this.onReorderStarted,
+    this.onReordering,
     this.scrollController,
     this.needsLongPressDraggable = true,
     this.draggingWidgetOpacity = 0.2,
@@ -93,6 +94,9 @@ class ReorderableFlex extends StatefulWidget {
 
   /// Called when the draggable starts being dragged.
   final ReorderStartedCallback? onReorderStarted;
+
+  /// Called while the draggable is being dragged.
+  final ReorderingCallback? onReordering;
 
   final BuildItemsContainer? buildItemsContainer;
   final BuildDraggableFeedback? buildDraggableFeedback;
@@ -142,6 +146,7 @@ class _ReorderableFlexState extends State<ReorderableFlex> {
           onReorder: widget.onReorder,
           onNoReorder: widget.onNoReorder,
           onReorderStarted: widget.onReorderStarted,
+          onReordering: widget.onReordering,
           padding: widget.padding,
           buildItemsContainer: widget.buildItemsContainer,
           buildDraggableFeedback: widget.buildDraggableFeedback,
@@ -183,6 +188,7 @@ class _ReorderableFlexContent extends StatefulWidget {
     required this.onReorder,
     required this.onNoReorder,
     required this.onReorderStarted,
+    required this.onReordering,
     required this.mainAxisAlignment,
     required this.scrollController,
     required this.needsLongPressDraggable,
@@ -202,6 +208,7 @@ class _ReorderableFlexContent extends StatefulWidget {
   final ReorderCallback onReorder;
   final NoReorderCallback? onNoReorder;
   final ReorderStartedCallback? onReorderStarted;
+  final ReorderingCallback? onReordering;
   final BuildItemsContainer? buildItemsContainer;
   final BuildDraggableFeedback? buildDraggableFeedback;
   final ScrollController? scrollController;
@@ -630,6 +637,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
                         opacity: 0,
                         child: Container(width: 0, height: 0, child: toWrap))),
                 onDragStarted: onDragStarted,
+                onDragUpdate: widget.onReordering,
                 dragAnchorStrategy: childDragAnchorStrategy,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
@@ -657,6 +665,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
                         opacity: 0,
                         child: Container(width: 0, height: 0, child: toWrap))),
                 onDragStarted: onDragStarted,
+                onDragUpdate: widget.onReordering,
                 dragAnchorStrategy: childDragAnchorStrategy,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
@@ -974,6 +983,7 @@ class ReorderableRow extends ReorderableFlex {
     BuildDraggableFeedback? buildDraggableFeedback,
     NoReorderCallback? onNoReorder,
     ReorderStartedCallback? onReorderStarted,
+    ReorderingCallback? onReordering,
     ScrollController? scrollController,
     bool needsLongPressDraggable = true,
     double draggingWidgetOpacity = 0.2,
@@ -988,6 +998,7 @@ class ReorderableRow extends ReorderableFlex {
             onReorder: onReorder,
             onNoReorder: onNoReorder,
             onReorderStarted: onReorderStarted,
+            onReordering: onReordering,
             direction: Axis.horizontal,
             scrollDirection: Axis.horizontal,
             padding: padding,
@@ -1055,6 +1066,7 @@ class ReorderableColumn extends ReorderableFlex {
     BuildDraggableFeedback? buildDraggableFeedback,
     NoReorderCallback? onNoReorder,
     ReorderStartedCallback? onReorderStarted,
+    ReorderingCallback? onReordering,
     ScrollController? scrollController,
     bool needsLongPressDraggable = true,
     double draggingWidgetOpacity = 0.2,
@@ -1069,6 +1081,7 @@ class ReorderableColumn extends ReorderableFlex {
             onReorder: onReorder,
             onNoReorder: onNoReorder,
             onReorderStarted: onReorderStarted,
+            onReordering: onReordering,
             direction: Axis.vertical,
             padding: padding,
             buildItemsContainer:

--- a/lib/src/widgets/reorderable_sliver.dart
+++ b/lib/src/widgets/reorderable_sliver.dart
@@ -244,6 +244,7 @@ class ReorderableSliverList extends StatefulWidget {
     this.buildDraggableFeedback,
     this.onNoReorder,
     this.onReorderStarted,
+    this.onReordering,
     this.onDragStart,
     this.onDragEnd,
     this.enabled = true,
@@ -267,6 +268,9 @@ class ReorderableSliverList extends StatefulWidget {
   /// children.
   final ReorderCallback onReorder;
   final NoReorderCallback? onNoReorder;
+
+  /// Called while the draggable is being dragged.
+  final ReorderingCallback? onReordering;
 
   /// Called when a drag process is started
   final VoidCallback? onDragStart;
@@ -811,6 +815,7 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
 //              child: _makeAppearingWidget(toWrap)
                       child: Container(width: 0, height: 0, child: toWrap)))),
           onDragStarted: onDragStarted,
+          onDragUpdate: widget.onReordering,
           dragAnchorStrategy: childDragAnchorStrategy,
           // When the drag ends inside a DragTarget widget, the drag
           // succeeds, and we reorder the widget into position appropriately.

--- a/lib/src/widgets/reorderable_table.dart
+++ b/lib/src/widgets/reorderable_table.dart
@@ -68,6 +68,7 @@ class ReorderableTable extends StatelessWidget {
     this.footer,
     this.decorateDraggableFeedback,
     this.onNoReorder,
+    this.onReordering,
     this.reorderAnimationDuration,
     this.scrollAnimationDuration,
     this.ignorePrimaryScrollController = false,
@@ -170,6 +171,10 @@ class ReorderableTable extends StatelessWidget {
   /// children.
   final ReorderCallback onReorder;
   final NoReorderCallback? onNoReorder;
+
+  /// Called while the draggable is being dragged.
+  final ReorderingCallback? onReordering;
+
   final DecorateDraggableFeedback? decorateDraggableFeedback;
   final Duration? reorderAnimationDuration;
   final Duration? scrollAnimationDuration;
@@ -195,6 +200,7 @@ class ReorderableTable extends StatelessWidget {
         footer: footer,
         children: children,
         onReorder: onReorder,
+        onReordering: onReordering,
         onNoReorder: onNoReorder,
         needsLongPressDraggable: needsLongPressDraggable,
         direction: Axis.vertical,

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -57,6 +57,7 @@ class ReorderableWrap extends StatefulWidget {
     this.maxMainAxisCount,
     this.onNoReorder,
     this.onReorderStarted,
+    this.onReordering,
     this.reorderAnimationDuration = const Duration(milliseconds: 200),
     this.scrollAnimationDuration = const Duration(milliseconds: 200),
     this.ignorePrimaryScrollController = false,
@@ -107,6 +108,9 @@ class ReorderableWrap extends StatefulWidget {
   /// children.
   final ReorderCallback onReorder;
   final NoReorderCallback? onNoReorder;
+
+  /// Called while the draggable is being dragged.
+  final ReorderingCallback? onReordering;
 
   /// Called when the draggable starts being dragged.
   final ReorderStartedCallback? onReorderStarted;
@@ -286,6 +290,7 @@ class _ReorderableWrapState extends State<ReorderableWrap> {
           onReorder: widget.onReorder,
           onNoReorder: widget.onNoReorder,
           onReorderStarted: widget.onReorderStarted,
+          onReordering: widget.onReordering,
           padding: widget.padding,
           buildItemsContainer: widget.buildItemsContainer,
           buildDraggableFeedback: widget.buildDraggableFeedback,
@@ -333,6 +338,7 @@ class _ReorderableWrapContent extends StatefulWidget {
     required this.onReorder,
     required this.onNoReorder,
     required this.onReorderStarted,
+    required this.onReordering,
     required this.buildItemsContainer,
     required this.buildDraggableFeedback,
     required this.needsLongPressDraggable,
@@ -364,6 +370,7 @@ class _ReorderableWrapContent extends StatefulWidget {
   final ReorderCallback onReorder;
   final NoReorderCallback? onNoReorder;
   final ReorderStartedCallback? onReorderStarted;
+  final ReorderingCallback? onReordering;
   final BuildItemsContainer? buildItemsContainer;
   final BuildDraggableFeedback? buildDraggableFeedback;
   final bool needsLongPressDraggable;
@@ -846,6 +853,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
                         //child: toWrap,//Container(width: 0, height: 0, child: toWrap)
                         child: _makeAppearingWidget(toWrap))),
                 onDragStarted: onDragStarted,
+                onDragUpdate: widget.onReordering,
                 // When the drag ends inside a DragTarget widget, the drag
                 // succeeds, and we reorder the widget into position appropriately.
                 onDragCompleted: onDragEnded,
@@ -873,6 +881,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
                   ),
                 ),
                 onDragStarted: onDragStarted,
+                onDragUpdate: widget.onReordering,
                 onDragCompleted: onDragEnded,
                 dragAnchorStrategy: childDragAnchorStrategy,
                 onDraggableCanceled: (Velocity velocity, Offset offset) =>

--- a/lib/src/widgets/typedefs.dart
+++ b/lib/src/widgets/typedefs.dart
@@ -7,3 +7,4 @@ typedef BuildDraggableFeedback = Widget Function(
 
 typedef NoReorderCallback = void Function(int index);
 typedef ReorderStartedCallback = void Function(int index);
+typedef ReorderingCallback = void Function(DragUpdateDetails details);


### PR DESCRIPTION
Add ReorderingCallback with DragUpdateDetails for:

- ReorderableFlex
- ReorderableSliver
- ReorderableTable
- ReorderableWrap

Workaround for #42 and possibly #137
As mentioned in the issues above, Reorderables do not scroll screen if inside parent ScrollView.
If we can pass the DragUpdateDetails we can atleast do it ourselves.