### PR TITLE
Fix for #146

### DIFF
--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -536,7 +536,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
 
   // Scrolls to a target context if that context is not on the screen.
   void _scrollTo(BuildContext context) {
-    if (_scrolling) return;
+    if (_scrolling || !_scrollController.hasClients) return;
     final RenderObject contextObject = context.findRenderObject()!;
     final RenderAbstractViewport viewport =
         RenderAbstractViewport.of(contextObject)!;


### PR DESCRIPTION
Long story short, `ReorderableWrap._scrollTo()` now checks whether its `ScrollController` has any clients before using it in that method. Fixes #146 