### PR TITLE
Fix crashes when using Flutter 3.7

### DIFF
--- a/example/lib/sliver_example.dart
+++ b/example/lib/sliver_example.dart
@@ -34,7 +34,7 @@ class _SliverExampleState extends State<SliverExample> {
     // Make sure there is a scroll controller attached to the scroll view that contains ReorderableSliverList.
     // Otherwise an error will be thrown.
     ScrollController _scrollController =
-        PrimaryScrollController.of(context) ?? ScrollController();
+        PrimaryScrollController.maybeOf(context) ?? ScrollController();
 
     return CustomScrollView(
       // A ScrollController must be included in CustomScrollView, otherwise

--- a/lib/src/widgets/reorderable_flex.dart
+++ b/lib/src/widgets/reorderable_flex.dart
@@ -317,11 +317,11 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
     }
 
     _scrollController = widget.scrollController ??
-        PrimaryScrollController.of(context) ??
+        PrimaryScrollController.maybeOf(context) ??
         ScrollController();
 
     if (_scrollController.hasClients) {
-      _attachedScrollPosition = Scrollable.of(context)?.position;
+      _attachedScrollPosition = Scrollable.maybeOf(context)?.position;
     } else {
       _attachedScrollPosition = null;
     }
@@ -376,7 +376,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
     if (_scrolling) return;
     final RenderObject contextObject = context.findRenderObject()!;
     final RenderAbstractViewport viewport =
-        RenderAbstractViewport.of(contextObject)!;
+        RenderAbstractViewport.of(contextObject);
     // If and only if the current scroll offset falls in-between the offsets
     // necessary to reveal the selected context at the top or bottom of the
     // screen, then it is already on-screen.
@@ -882,7 +882,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
 //      );
 
     if (widget.scrollController != null &&
-        PrimaryScrollController.of(context) == null) {
+        PrimaryScrollController.maybeOf(context) == null) {
       return (widget.buildItemsContainer ?? defaultBuildItemsContainer)(
           context, widget.direction, wrappedChildren);
     } else {

--- a/lib/src/widgets/reorderable_sliver.dart
+++ b/lib/src/widgets/reorderable_sliver.dart
@@ -384,11 +384,12 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
     }
 
     _scrollController = widget.controller ??
-        PrimaryScrollController.of(context) ??
+        PrimaryScrollController.maybeOf(context) ??
         ScrollController();
 
-    _attachedScrollPosition =
-        _scrollController.hasClients ? null : Scrollable.of(context)?.position;
+    _attachedScrollPosition = _scrollController.hasClients
+        ? null
+        : Scrollable.maybeOf(context)?.position;
 
     if (_attachedScrollPosition != null) {
       _scrollController.attach(_attachedScrollPosition!);
@@ -498,7 +499,7 @@ class _ReorderableSliverListState extends State<ReorderableSliverList>
     if (_scrolling) return;
     final RenderObject contextObject = context.findRenderObject()!;
     final RenderAbstractViewport viewport =
-        RenderAbstractViewport.of(contextObject)!;
+        RenderAbstractViewport.of(contextObject);
 
 //    if (_scrollController.positions.isEmpty) {
 //      debugPrint('${DateTime.now().toString().substring(5, 22)} reorderable_sliver.dart(537) $this._scrollTo: empty pos');

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -324,34 +324,35 @@ class _ReorderableWrapState extends State<ReorderableWrap> {
 // This widget is responsible for the inside of the Overlay in the
 // ReorderableListView.
 class _ReorderableWrapContent extends StatefulWidget {
-  const _ReorderableWrapContent(
-      {required this.children,
-      required this.direction,
-      required this.scrollDirection,
-      required this.scrollPhysics,
-      required this.padding,
-      required this.onReorder,
-      required this.onNoReorder,
-      required this.onReorderStarted,
-      required this.buildItemsContainer,
-      required this.buildDraggableFeedback,
-      required this.needsLongPressDraggable,
-      required this.alignment,
-      required this.spacing,
-      required this.runAlignment,
-      required this.runSpacing,
-      required this.crossAxisAlignment,
-      required this.textDirection,
-      required this.verticalDirection,
-      required this.minMainAxisCount,
-      required this.maxMainAxisCount,
-      this.header,
-      this.footer,
-      this.controller,
-      this.reorderAnimationDuration = const Duration(milliseconds: 200),
-      this.scrollAnimationDuration = const Duration(milliseconds: 200),
-      required this.enableReorder});
-
+  const _ReorderableWrapContent({
+    required this.children,
+    required this.direction,
+    required this.scrollDirection,
+    required this.scrollPhysics,
+    required this.padding,
+    required this.onReorder,
+    required this.onNoReorder,
+    required this.onReorderStarted,
+    required this.buildItemsContainer,
+    required this.buildDraggableFeedback,
+    required this.needsLongPressDraggable,
+    required this.alignment,
+    required this.spacing,
+    required this.runAlignment,
+    required this.runSpacing,
+    required this.crossAxisAlignment,
+    required this.textDirection,
+    required this.verticalDirection,
+    required this.minMainAxisCount,
+    required this.maxMainAxisCount,
+    this.header,
+    this.footer,
+    this.controller,
+    this.reorderAnimationDuration = const Duration(milliseconds: 200),
+    this.scrollAnimationDuration = const Duration(milliseconds: 200),
+    required this.enableReorder
+  });
+  
   final List<Widget>? header;
   final Widget? footer;
   final ScrollController? controller;

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -324,34 +324,33 @@ class _ReorderableWrapState extends State<ReorderableWrap> {
 // This widget is responsible for the inside of the Overlay in the
 // ReorderableListView.
 class _ReorderableWrapContent extends StatefulWidget {
-  const _ReorderableWrapContent({
-    required this.children,
-    required this.direction,
-    required this.scrollDirection,
-    required this.scrollPhysics,
-    required this.padding,
-    required this.onReorder,
-    required this.onNoReorder,
-    required this.onReorderStarted,
-    required this.buildItemsContainer,
-    required this.buildDraggableFeedback,
-    required this.needsLongPressDraggable,
-    required this.alignment,
-    required this.spacing,
-    required this.runAlignment,
-    required this.runSpacing,
-    required this.crossAxisAlignment,
-    required this.textDirection,
-    required this.verticalDirection,
-    required this.minMainAxisCount,
-    required this.maxMainAxisCount,
-    this.header,
-    this.footer,
-    this.controller,
-    this.reorderAnimationDuration = const Duration(milliseconds: 200),
-    this.scrollAnimationDuration = const Duration(milliseconds: 200),
-    required this.enableReorder
-  });
+  const _ReorderableWrapContent(
+      {required this.children,
+      required this.direction,
+      required this.scrollDirection,
+      required this.scrollPhysics,
+      required this.padding,
+      required this.onReorder,
+      required this.onNoReorder,
+      required this.onReorderStarted,
+      required this.buildItemsContainer,
+      required this.buildDraggableFeedback,
+      required this.needsLongPressDraggable,
+      required this.alignment,
+      required this.spacing,
+      required this.runAlignment,
+      required this.runSpacing,
+      required this.crossAxisAlignment,
+      required this.textDirection,
+      required this.verticalDirection,
+      required this.minMainAxisCount,
+      required this.maxMainAxisCount,
+      this.header,
+      this.footer,
+      this.controller,
+      this.reorderAnimationDuration = const Duration(milliseconds: 200),
+      this.scrollAnimationDuration = const Duration(milliseconds: 200),
+      required this.enableReorder});
 
   final List<Widget>? header;
   final Widget? footer;
@@ -497,7 +496,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
   @override
   void didChangeDependencies() {
     _scrollController = widget.controller ??
-        PrimaryScrollController.of(context) ??
+        PrimaryScrollController.maybeOf(context) ??
         ScrollController();
     super.didChangeDependencies();
   }
@@ -539,7 +538,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
     if (_scrolling || !_scrollController.hasClients) return;
     final RenderObject contextObject = context.findRenderObject()!;
     final RenderAbstractViewport viewport =
-        RenderAbstractViewport.of(contextObject)!;
+        RenderAbstractViewport.of(contextObject);
     // If and only if the current scroll offset falls in-between the offsets
     // necessary to reveal the selected context at the top or bottom of the
     // screen, then it is already on-screen.
@@ -1228,7 +1227,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
     }
 
     if (widget.controller != null &&
-        PrimaryScrollController.of(context) == null) {
+        PrimaryScrollController.maybeOf(context) == null) {
       return (widget.buildItemsContainer ?? defaultBuildItemsContainer)(
           context, widget.direction, wrappedChildren);
     } else {


### PR DESCRIPTION
Fixes #167 PrimaryScrollController.of() was called with a context that does not contain a PrimaryScrollController widget thrown after flutter upgrade