### PR TITLE
Add draggable/DragDelay option to ReorderableSliverList + all other widgets

### DIFF
--- a/lib/reorderables.dart
+++ b/lib/reorderables.dart
@@ -5,3 +5,4 @@ export 'src/widgets/reorderable_sliver.dart';
 export 'src/widgets/reorderable_table.dart';
 export 'src/widgets/reorderable_widget.dart';
 export 'src/widgets/reorderable_wrap.dart';
+export 'src/drag_delay_enum.dart';

--- a/lib/src/drag_delay_enum.dart
+++ b/lib/src/drag_delay_enum.dart
@@ -1,0 +1,1 @@
+enum DragDelay { short, long }

--- a/lib/src/widgets/reorderable_flex.dart
+++ b/lib/src/widgets/reorderable_flex.dart
@@ -11,6 +11,7 @@ import './passthrough_overlay.dart';
 import './reorderable_mixin.dart';
 import './reorderable_widget.dart';
 import './typedefs.dart';
+import '../drag_delay_enum.dart';
 
 /// Reorderable (drag and drop) version of [Flex], a widget that displays its
 /// draggable children in a one-dimensional array.
@@ -26,7 +27,7 @@ import './typedefs.dart';
 /// top/left and bottom/right of the widget. If further control is needed, you
 /// can use [buildItemsContainer] to customize how each item is contained, or
 /// use [buildDraggableFeedback] to customize the [feedback] of the internal
-/// [LongPressDraggable]. Consider using [ReorderableRow] or [ReorderableColumn]
+/// [Draggable] widget. Consider using [ReorderableRow] or [ReorderableColumn]
 /// instead using this widget directly.
 ///
 /// All [children] must have a key.
@@ -52,7 +53,7 @@ class ReorderableFlex extends StatefulWidget {
     this.onNoReorder,
     this.onReorderStarted,
     this.scrollController,
-    this.needsLongPressDraggable = true,
+    this.dragDelay = DragDelay.long,
     this.draggingWidgetOpacity = 0.2,
     this.reorderAnimationDuration,
     this.scrollAnimationDuration,
@@ -102,7 +103,7 @@ class ReorderableFlex extends StatefulWidget {
 
   final MainAxisAlignment mainAxisAlignment;
 
-  final bool needsLongPressDraggable;
+  final DragDelay dragDelay;
   final double draggingWidgetOpacity;
 
   final Duration? reorderAnimationDuration;
@@ -150,7 +151,7 @@ class _ReorderableFlexState extends State<ReorderableFlex> {
           buildDraggableFeedback: widget.buildDraggableFeedback,
           mainAxisAlignment: widget.mainAxisAlignment,
           scrollController: widget.scrollController,
-          needsLongPressDraggable: widget.needsLongPressDraggable,
+          dragDelay: widget.dragDelay,
           draggingWidgetOpacity: widget.draggingWidgetOpacity,
           draggedItemBuilder: widget.draggedItemBuilder,
           reorderAnimationDuration: widget.reorderAnimationDuration ??
@@ -189,7 +190,7 @@ class _ReorderableFlexContent extends StatefulWidget {
     required this.onReorderStarted,
     required this.mainAxisAlignment,
     required this.scrollController,
-    required this.needsLongPressDraggable,
+    required this.dragDelay,
     required this.draggingWidgetOpacity,
     required this.buildItemsContainer,
     required this.buildDraggableFeedback,
@@ -214,7 +215,7 @@ class _ReorderableFlexContent extends StatefulWidget {
   final Widget Function(BuildContext context, int index)? draggedItemBuilder;
 
   final MainAxisAlignment mainAxisAlignment;
-  final bool needsLongPressDraggable;
+  final DragDelay dragDelay;
   final double draggingWidgetOpacity;
   final Duration reorderAnimationDuration;
   final Duration scrollAnimationDuration;
@@ -601,7 +602,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
       if (!isReorderable) {
         child = toWrap;
       } else {
-        child = widget.needsLongPressDraggable
+        child = widget.dragDelay == DragDelay.long
             ? LongPressDraggable<int>(
                 maxSimultaneousDrags: 1,
                 axis: widget.direction,
@@ -947,7 +948,7 @@ class _ReorderableFlexContentState extends State<_ReorderableFlexContent>
 /// In addition to other parameters in [Row]'s constructor, this widget also
 /// has [header] and [footer] for placing non-reorderable widgets at the top and
 /// bottom of the widget, and [buildDraggableFeedback] to customize the
-/// [feedback] widget of the internal [LongPressDraggable].
+/// [feedback] widget of the internal [Draggable].
 ///
 /// The [onReorder] function must be defined. A typical onReorder function looks
 /// like the following:
@@ -984,7 +985,7 @@ class ReorderableRow extends ReorderableFlex {
     NoReorderCallback? onNoReorder,
     ReorderStartedCallback? onReorderStarted,
     ScrollController? scrollController,
-    bool needsLongPressDraggable = true,
+    DragDelay dragDelay = DragDelay.long,
     double draggingWidgetOpacity = 0.2,
     Duration? reorderAnimationDuration,
     Duration? scrollAnimationDuration,
@@ -1017,7 +1018,7 @@ class ReorderableRow extends ReorderableFlex {
             buildDraggableFeedback: buildDraggableFeedback,
             mainAxisAlignment: mainAxisAlignment,
             scrollController: scrollController,
-            needsLongPressDraggable: needsLongPressDraggable,
+            dragDelay: dragDelay,
             draggingWidgetOpacity: draggingWidgetOpacity,
             reorderAnimationDuration: reorderAnimationDuration,
             scrollAnimationDuration: scrollAnimationDuration,
@@ -1030,7 +1031,7 @@ class ReorderableRow extends ReorderableFlex {
 /// In addition to other parameters in [Column]'s constructor, this widget also
 /// has [header] and [footer] for placing non-reorderable widgets at the left and
 /// right of the widget, and [buildDraggableFeedback] to customize the
-/// [feedback] widget of the internal [LongPressDraggable].
+/// [feedback] widget of the internal [Draggable].
 ///
 /// The [onReorder] function must be defined. A typical onReorder function looks
 /// like the following:
@@ -1067,7 +1068,7 @@ class ReorderableColumn extends ReorderableFlex {
     NoReorderCallback? onNoReorder,
     ReorderStartedCallback? onReorderStarted,
     ScrollController? scrollController,
-    bool needsLongPressDraggable = true,
+    DragDelay dragDelay = DragDelay.long,
     double draggingWidgetOpacity = 0.2,
     Duration? reorderAnimationDuration,
     Duration? scrollAnimationDuration,
@@ -1098,7 +1099,7 @@ class ReorderableColumn extends ReorderableFlex {
             buildDraggableFeedback: buildDraggableFeedback,
             mainAxisAlignment: mainAxisAlignment,
             scrollController: scrollController,
-            needsLongPressDraggable: needsLongPressDraggable,
+            dragDelay: dragDelay,
             draggingWidgetOpacity: draggingWidgetOpacity,
             reorderAnimationDuration: reorderAnimationDuration,
             scrollAnimationDuration: scrollAnimationDuration,

--- a/lib/src/widgets/reorderable_table.dart
+++ b/lib/src/widgets/reorderable_table.dart
@@ -5,6 +5,7 @@ import './reorderable_flex.dart';
 import './tabluar_flex.dart';
 import './typedefs.dart';
 import '../rendering/tabluar_flex.dart';
+import '../drag_delay_enum.dart';
 
 class ReorderableTableRow extends TabluarRow {
   ReorderableTableRow({
@@ -71,7 +72,7 @@ class ReorderableTable extends StatelessWidget {
     this.reorderAnimationDuration,
     this.scrollAnimationDuration,
     this.ignorePrimaryScrollController = false,
-    this.needsLongPressDraggable = true,
+    this.dragDelay = DragDelay.long,
     Key? key,
     this.borderColor,
   })  : assert(() {
@@ -175,7 +176,7 @@ class ReorderableTable extends StatelessWidget {
   final Duration? scrollAnimationDuration;
   final bool ignorePrimaryScrollController;
 
-  final bool needsLongPressDraggable;
+  final DragDelay dragDelay;
 
   @override
   Widget build(BuildContext context) {
@@ -196,7 +197,7 @@ class ReorderableTable extends StatelessWidget {
         children: children,
         onReorder: onReorder,
         onNoReorder: onNoReorder,
-        needsLongPressDraggable: needsLongPressDraggable,
+        dragDelay: dragDelay,
         direction: Axis.vertical,
         buildItemsContainer: (BuildContext containerContext, Axis direction,
             List<Widget> children) {

--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -45,7 +45,7 @@ class ReorderableWrap extends StatefulWidget {
     this.padding,
     this.buildItemsContainer,
     this.buildDraggableFeedback,
-    this.needsLongPressDraggable = true,
+    this.dragDelay = DragDelay.long,
     this.alignment = WrapAlignment.start,
     this.spacing = 0.0,
     this.runAlignment = WrapAlignment.start,
@@ -114,9 +114,9 @@ class ReorderableWrap extends StatefulWidget {
   final BuildItemsContainer? buildItemsContainer;
   final BuildDraggableFeedback? buildDraggableFeedback;
 
-  /// The flag of whether needs long press to trigger dragging mode.
-  /// true means it needs long press and false means no need.
-  final bool needsLongPressDraggable;
+  /// Enum flag used to determine if a long press or a short press is needed to
+  /// trigger dragging mode. DragDelay.long is the default
+  final DragDelay dragDelay;
 
   /// How the children within a run should be places in the main axis.
   ///
@@ -289,7 +289,7 @@ class _ReorderableWrapState extends State<ReorderableWrap> {
           padding: widget.padding,
           buildItemsContainer: widget.buildItemsContainer,
           buildDraggableFeedback: widget.buildDraggableFeedback,
-          needsLongPressDraggable: widget.needsLongPressDraggable,
+          dragDelay: widget.dragDelay,
           alignment: widget.alignment,
           spacing: widget.spacing,
           runAlignment: widget.runAlignment,
@@ -335,7 +335,7 @@ class _ReorderableWrapContent extends StatefulWidget {
     required this.onReorderStarted,
     required this.buildItemsContainer,
     required this.buildDraggableFeedback,
-    required this.needsLongPressDraggable,
+    required this.dragDelay,
     required this.alignment,
     required this.spacing,
     required this.runAlignment,
@@ -352,7 +352,7 @@ class _ReorderableWrapContent extends StatefulWidget {
     this.scrollAnimationDuration = const Duration(milliseconds: 200),
     required this.enableReorder
   });
-  
+
   final List<Widget>? header;
   final Widget? footer;
   final ScrollController? controller;
@@ -366,7 +366,7 @@ class _ReorderableWrapContent extends StatefulWidget {
   final ReorderStartedCallback? onReorderStarted;
   final BuildItemsContainer? buildItemsContainer;
   final BuildDraggableFeedback? buildDraggableFeedback;
-  final bool needsLongPressDraggable;
+  final DragDelay dragDelay;
 
   final WrapAlignment alignment;
   final double spacing;
@@ -826,7 +826,7 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
       } else {
         // We build the draggable inside of a layout builder so that we can
         // constrain the size of the feedback dragging widget.
-        child = this.widget.needsLongPressDraggable
+        child = this.widget.dragDelay == DragDelay.long
             ? LongPressDraggable<int>(
                 maxSimultaneousDrags: 1,
                 data: index,


### PR DESCRIPTION
Fixes #24 
Adds a DragDelay enum option for all widgets (including ReorderableSliverList), replacing needsLongPressDraggable boolean. 

I thought having an enum would be easier to understand than setting "needsLongPressDraggable" = true or false.

Could also address #133 & #35 but would need to add reference to enum in the docs.